### PR TITLE
add  to tags to allow compatibility with steeltoe

### DIFF
--- a/redislabs/broker.go
+++ b/redislabs/broker.go
@@ -68,7 +68,7 @@ func (b *serviceBroker) Services() []brokerapi.Service {
 			Name:          b.Config.ServiceBroker.Name,
 			Description:   b.Config.ServiceBroker.Description,
 			Bindable:      true,
-			Tags:          []string{"redislabs"},
+			Tags:          []string{"redislabs", "redis"},
 			Plans:         planList,
 			PlanUpdatable: true,
 			Metadata: &brokerapi.ServiceMetadata{


### PR DESCRIPTION
Issue reported with steeltoe config management, need to add `redis` to service broker tags to allow for compatibility 
